### PR TITLE
Noarch hamlib-all can't depend on hamlib-perl on osx

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set version = "4.5.5" %}
 {% set soversion = "4" %}
-{% set build = 1 %}
+{% set build = 2 %}
 {% set posix = 'm2-' if win else '' %}
 {% set library = "Library/" if win else "" %}
 
@@ -219,17 +219,19 @@ outputs:
   - name: hamlib-all
     build:
       noarch: generic
-      string: "unix_{{ build }}"  # [unix]
+      string: "linux_{{ build }}"  # [linux]
+      string: "osx_{{ build }}"  # [osx]
       string: "win_{{ build }}"  # [win]
       run_exports:
         - {{ pin_subpackage('libhamlib' + soversion, max_pin=False) }}
     requirements:
       run:
-        - __unix  # [unix]
+        - __linux  # [linux]
+        - __osx  # [osx]
         - __win  # [win]
         - hamlib {{ version }}
         - hamlib-lua {{ version }}
-        - hamlib-perl {{ version }}  # [not win and build_platform == target_platform]
+        - hamlib-perl {{ version }}  # [not win and not osx]
         - hamlib-python {{ version }}
         - hamlib-tcl {{ version }}
     test:


### PR DESCRIPTION
... until we can get `hamlib-perl` built for osx-arm64.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
